### PR TITLE
WR309191 add redis check

### DIFF
--- a/index.php
+++ b/index.php
@@ -98,7 +98,7 @@ if ($fullcheck || $checksession) {
     if ($sessioncheck = json_decode($response)) {
         if ($sessioncheck->success == 'pass') {
             if ($sessioncheck->latency > 5) {
-                echo "Session latency outside of acceptable range: {$sessioncheck->latency} seconds.";
+                echo "Session latency outside of acceptable range: {$sessioncheck->latency} seconds.<br>\n";
                 send_warning($sessiondriver . ' session');
             }
             $status .= "Session check OK, Session Handler: " . $sessiondriver . "<br>\n";
@@ -107,11 +107,11 @@ if ($fullcheck || $checksession) {
                 . "Request host: {$sessioncheck->requesthost}, "
                 . "Response host: {$sessioncheck->responsehost}, "
                 . "Latency (seconds): {$sessioncheck->latency}, "
-                . "Session Handler: " . $sessiondriver);
+                . "Session Handler: " . $sessiondriver) . "<br>\n";
             send_critical($sessiondriver . ' session');
         }
     } else {
-        echo 'Session check could not be conducted, error connecting to session check URL';
+        echo "Session check could not be conducted, error connecting to session check URL<br>\n";
         send_warning($sessiondriver . ' session');
     }
 }

--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@
 
 use core\session\manager;
 
-require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
 
 // Make sure varnish doesn't cache this. But it still might so go check it!
 header('Pragma: no-cache');
@@ -53,14 +53,15 @@ if (!defined(CLI_SCRIPT)) {
     $checksession = isset($_GET['checksession']);
 }
 define('NO_UPGRADE_CHECK', true);
-define('ABORT_AFTER_CONFIG', true);
 
 if (check_climaintenance(__DIR__ . '/../../../config.php') === true) {
     print "Server is in MAINTENANCE<br>\n";
     exit;
 }
 
+define('ABORT_AFTER_CONFIG_CANCEL', true);
 require_once(__DIR__ . '/../../../config.php');
+require_once(__DIR__ . '/nagios.php');
 
 global $CFG;
 
@@ -70,18 +71,14 @@ $status = "";
 $testfile = $CFG->dataroot . "/tool_heartbeat.test";
 $size = file_put_contents($testfile, '1');
 if ($size !== 1) {
-    failed('sitedata not writable');
+    send_critical('sitedata not writable');
 }
 
 if (file_exists($testfile)) {
     $status .= "sitedata OK<br>\n";
 } else {
-    failed('sitedata not readable');
+    send_critical('sitedata not readable');
 }
-
-define('ABORT_AFTER_CONFIG_CANCEL', true);
-require($CFG->dirroot . '/lib/setup.php');
-require_once($CFG->libdir.'/filelib.php');
 
 // IP Locking, check for CLI, check for remote IP in validated list, if not, exit.
 if (!(isset($argv))) {
@@ -92,6 +89,9 @@ $sessionclass = manager::get_handler_class();
 $sessionclasspatharray = explode('\\', $sessionclass);
 $sessiondriver = end($sessionclasspatharray);
 
+// Require the filelib to bootstrap curl.
+require_once($CFG->libdir . '/filelib.php');
+
 if ($fullcheck || $checksession) {
     $c = new curl(array('cache' => false, 'cookie' => true));
     $response = $c->get(new moodle_url('/admin/tool/heartbeat/sessionone.php'));
@@ -99,7 +99,7 @@ if ($fullcheck || $checksession) {
         if ($sessioncheck->success == 'pass') {
             if ($sessioncheck->latency > 5) {
                 echo "Session latency outside of acceptable range: {$sessioncheck->latency} seconds.";
-                failed($sessiondriver . ' session');
+                send_warning($sessiondriver . ' session');
             }
             $status .= "Session check OK, Session Handler: " . $sessiondriver . "<br>\n";
         } else {
@@ -108,11 +108,11 @@ if ($fullcheck || $checksession) {
                 . "Response host: {$sessioncheck->responsehost}, "
                 . "Latency (seconds): {$sessioncheck->latency}, "
                 . "Session Handler: " . $sessiondriver);
-            failed($sessiondriver . ' session');
+            send_critical($sessiondriver . ' session');
         }
     } else {
         echo 'Session check could not be conducted, error connecting to session check URL';
-        failed($sessiondriver . ' session');
+        send_warning($sessiondriver . ' session');
     }
 }
 
@@ -121,7 +121,7 @@ if ($sessiondriver == 'redis') {
     if (tool_heartbeat_redis_check()) {
         $status .= "Redis check OKAY</br>\n";
     } else {
-        failed($sessiondriver . ' session');
+        send_warning($sessiondriver . ' session');
     }
 }
 
@@ -140,12 +140,12 @@ if ($sessiondriver == 'memcached' && property_exists($CFG, 'session_memcached_sa
         if ($stats[$addr . ':' . $port]['uptime'] > 0) {
             $status .= "session memcached OK<br>\n";
         } else {
-            failed('sessions memcached');
+            send_warning('sessions memcached');
         }
     } catch (Exception $e) {
-        failed('sessions memcached');
+        send_warning('sessions memcached');
     } catch (Throwable $e) {
-        failed('sessions memcached');
+        send_warning('sessions memcached');
     }
 
 }
@@ -159,15 +159,16 @@ if ($fullcheck) {
         if ($user) {
             $status .= "database OK<br>\n";
         } else {
-            failed('no users in database');
+            send_critical('no users in database');
         }
     } catch (Exception $e) {
-        failed('database error');
+        send_critical('database error');
     } catch (Throwable $e) {
-        failed('database error');
+        send_critical('database error');
     }
 }
 
 print "Server is ALIVE<br>\n";
 print $status;
+send_good('Server is ALIVE');
 

--- a/index.php
+++ b/index.php
@@ -168,7 +168,6 @@ if ($fullcheck) {
     }
 }
 
-print "Server is ALIVE<br>\n";
 print $status;
 send_good('Server is ALIVE');
 

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,97 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+use core\session\util;
+
+/**
+ * This file contains functions used by tool_heartbeat.
+ *
+ * @package    tool_heartbeat
+ * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Return an error that ELB will pick up
+ *
+ * @param string $reason
+ */
+function failed($reason) {
+    // Status for ELB, will cause ELB to remove instance.
+    header("HTTP/1.0 503 Service unavailable: failed $reason check");
+    // Status for the humans.
+    print "Server is DOWN<br>\n";
+    echo "Failed: $reason";
+    exit;
+}
+
+/**
+ * Checks if the command line maintenance mode has been enabled. Skip the config bootstrapping.
+ *
+ * @param string $configfile The relative path for config.php
+ * @return bool True if climaintenance.html is found.
+ */
+function check_climaintenance($configfile) {
+    $content = file_get_contents($configfile);
+    $content = preg_replace("#[^!:]//#", "\n//", $content);  // Set comments to be on newlines, replace '//' with '\n//', where // does not start with :
+    $content = preg_replace("/;/", ";\n", $content);         // Split up statements, replace ';' with ';\n'
+    $content = preg_replace("/^[\s]+/m", "", $content);      // Removes all initial whitespace and newlines.
+
+    $re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot
+    preg_match($re, $content, $matches);
+    if (!empty($matches)) {
+        $climaintenance = $matches[count($matches) - 1] . '/climaintenance.html';
+
+        if (file_exists($climaintenance)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Check if configured redis instance is working by connecting and storing a key => value
+ * based on date, then retrieving it to make sure it's the same.
+ *
+ * @return bool true if check passed, false otherwise.
+ */
+function tool_heartbeat_redis_check() {
+    global $CFG;
+    $redistestkey = 'redis_test_key:' . date(DATE_ATOM);
+    $redistestvalue = 'redis_test_value:' .date(DATE_ATOM);
+
+    // Build a standalone redis connection to the store to remove Moodle APIs as a potential factor.
+    try {
+        $redis = new Redis();
+        $redis->connect($CFG->session_redis_host, $CFG->session_redis_port, 2);
+        if (isset($CFG->session_redis_auth) && !empty($CFG->session_redis_auth)) {
+            $redis->auth($CFG->session_redis_auth);
+        }// Ping the server first.
+        $ping = $redis->ping();
+        if ($ping == '+PONG') {
+            // Store a value and retrieve, checking it's the same.
+            $redis->set($redistestkey, $redistestvalue);
+            if ($redis->get($redistestkey) === $redistestvalue) {
+                return true;
+            }
+        }
+        $redis->close();
+        return false;
+    } catch (Exception $e) {
+        debugging($e->getMessage());
+        return false;
+    }
+}

--- a/locallib.php
+++ b/locallib.php
@@ -25,20 +25,6 @@ use core\session\util;
  */
 
 /**
- * Return an error that ELB will pick up
- *
- * @param string $reason
- */
-function failed($reason) {
-    // Status for ELB, will cause ELB to remove instance.
-    header("HTTP/1.0 503 Service unavailable: failed $reason check");
-    // Status for the humans.
-    print "Server is DOWN<br>\n";
-    echo "Failed: $reason";
-    exit;
-}
-
-/**
  * Checks if the command line maintenance mode has been enabled. Skip the config bootstrapping.
  *
  * @param string $configfile The relative path for config.php

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019070900;
+$plugin->version   = 2019073000;
 $plugin->release   = 2019070900; // Match release exactly to version.
 $plugin->requires  = 2012120311; // Deep support going back to 2.4
 $plugin->component = 'tool_heartbeat';


### PR DESCRIPTION
This improvement adds an explicit Redis check which, if Redis is the Session handler for Moodle, creates a connection (outside of Moodle APIs and libraries, in order to remove this as a variability for failure) and sends a timestamped key value pair to the Redis store, before retrieving and checking the value, updating the status if passing or calling a fail function if not.