### PR TITLE
Add MemcachedUtil, which has been deleted from moodle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,3 @@ http://moodle.local/admin/settings.php?section=tool_heartbeat
 When you have first setup this plugin and wired it end to end with Nagios / Icinga or another monitoring tool, you want the peace of mind to know that it is all correctly working. There is a setting which allows you to send a fake warning so you can confirm your pager will go off. This setting is set to 'error' by default by design
 
 http://moodle.local/admin/settings.php?section=tool_heartbeat
-
-
-
-

--- a/classes/MemcachedUtil.php
+++ b/classes/MemcachedUtil.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Class MemcachedUtil.
+ * Contains Memcached Utility function which has been made inaccessible in moodle core.
+ */
+abstract class MemcachedUtil {
+    /**
+     * Convert a connection string to an array of servers
+     *
+     * EG: Converts: "abc:123, xyz:789" to
+     *
+     *  array(
+     *      array('abc', '123'),
+     *      array('xyz', '789'),
+     *  )
+     *
+     * @copyright  2013 Moodlerooms Inc. (http://www.moodlerooms.com)
+     * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+     * @author     Mark Nielsen
+     *
+     * @param string $str save_path value containing memcached connection string
+     * @return array
+     */
+    public static function connection_string_to_memcache_servers($str) {
+        $servers = array();
+        $parts   = explode(',', $str);
+        foreach ($parts as $part) {
+            $part = trim($part);
+            $pos  = strrpos($part, ':');
+            if ($pos !== false) {
+                $host = substr($part, 0, $pos);
+                $port = substr($part, ($pos + 1));
+            } else {
+                $host = $part;
+                $port = 11211;
+            }
+            $servers[] = array($host, $port);
+        }
+        return $servers;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -148,8 +148,8 @@ $sessionhandler = (property_exists($CFG, 'session_handler_class') && $CFG->sessi
 $savepath = property_exists($CFG, 'session_memcached_save_path');
 
 if ($sessionhandler && $savepath) {
-    require_once($CFG->libdir . '/classes/session/util.php');
-    $servers = \core\session\util::connection_string_to_memcache_servers($CFG->session_memcached_save_path);
+    require_once(__DIR__ .'/classes/MemcachedUtil.php');
+    $servers = MemcachedUtil::connection_string_to_memcache_servers($CFG->session_memcached_save_path);
     try {
         $memcached = new \Memcached();
         $memcached->addServers($servers);


### PR DESCRIPTION

core\session\util class has been removed in Moodle 3.6:
https://github.com/moodle/moodle/blob/11b094be4c8c6b58a745149fd0006a3f198b2e86/lib/upgrade.txt