### PR TITLE
Remove get_name() calls for adhoc tasks on the cron check page

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -230,7 +230,7 @@ foreach ($tasks as $task) {
     if ($faildelay > $maxdelay) {
         $maxdelay = $faildelay;
     }
-    $delay .= "TASK: " . $task->get_name() . ' (' .get_class($task) . ") Delay: $faildelay\n";
+    $delay .= "SCHEDULED TASK: " . get_class($task) . ' (' .$task->get_name() . ") Delay: $faildelay\n";
 }
 
 $records = $DB->get_records_sql('SELECT * from {task_adhoc} WHERE faildelay > 0');
@@ -247,7 +247,7 @@ foreach ($records as $record) {
     if ($faildelay > $maxdelay) {
         $maxdelay = $faildelay;
     }
-    $delay .= "TASK: " . $task->get_name() . ' (' .get_class($task) . ") Delay: $faildelay\n";
+    $delay .= "ADHOC TASK: " .get_class($task) . " Delay: $faildelay\n";
 }
 
 if ( empty($legacylastrun) ) {

--- a/progress.php
+++ b/progress.php
@@ -47,7 +47,7 @@ echo $OUTPUT->footer();
 // stack and not the test, so we have just added more margin here.
 $total = 10;
 $progressbar->update_full(0, '0%');
-for ($c = 1; $c <= 100; $c+= .2) {
+for ($c = 1; $c <= 100; $c += .2) {
     usleep($total * 10000);
     $progressbar->update_full($c, sprintf("You are up to %.1f out of 100", $c));
 }


### PR DESCRIPTION
This is a fix for the issue #91 