### PR TITLE
Allow detection of maintenance mode with dataroot set as variable

### DIFF
--- a/index.php
+++ b/index.php
@@ -70,12 +70,11 @@ function check_climaintenance($configfile) {
     $re = '/^\$CFG->dataroot\s+=\s+(.*?);/m';  // Lines starting with $CFG->dataroot.
     preg_match($re, $content, $matches);
     
-    print_r($matches);
-    $dataroot = $matches[count($matches) - 1];
-    echo "dataroot=".$dataroot;
-    
     if (!empty($matches)) {
-        $climaintenance = $matches[count($matches) - 1] . '/climaintenance.html';
+        // We trust what we found is safe because it was found in the site's config.php
+        // This eval makes it so that any use of getenv() or other variables to feed that dataroot variable will be parsed correctly
+        eval($matches[0]);
+        $climaintenance = $CFG->dataroot . '/climaintenance.html';
 
         if (file_exists($climaintenance)) {
             return true;

--- a/index.php
+++ b/index.php
@@ -68,7 +68,6 @@ function check_climaintenance($configfile) {
 
     $re = '/^\$CFG->dataroot\s+=\s+(.*?);/m';  // Lines starting with $CFG->dataroot.
     preg_match($re, $content, $matches);
-
     if (!empty($matches)) {
         // We trust what we found is safe because it was found in the site's config.php
         // This eval makes it so that any use of getenv() or other variables to feed that dataroot variable will be parsed correctly

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ function check_climaintenance($configfile) {
     if (!empty($matches)) {
         // We trust what we found is safe because it was found in the site's config.php
         // This eval makes it so that any use of getenv() or other variables to feed that dataroot variable will be parsed correctly
-        print_r($matches);
+        $CFG = new stdClass();
         eval($matches[0]);
         $climaintenance = $CFG->dataroot . '/climaintenance.html';
 

--- a/index.php
+++ b/index.php
@@ -73,6 +73,7 @@ function check_climaintenance($configfile) {
     if (!empty($matches)) {
         // We trust what we found is safe because it was found in the site's config.php
         // This eval makes it so that any use of getenv() or other variables to feed that dataroot variable will be parsed correctly
+        print_r($matches);
         eval($matches[0]);
         $climaintenance = $CFG->dataroot . '/climaintenance.html';
 

--- a/index.php
+++ b/index.php
@@ -68,6 +68,9 @@ function check_climaintenance($configfile) {
 
     $re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot.
     preg_match($re, $content, $matches);
+    
+    print_r($matches);
+    
     if (!empty($matches)) {
         $climaintenance = $matches[count($matches) - 1] . '/climaintenance.html';
 
@@ -84,18 +87,8 @@ if (check_climaintenance(__DIR__ . '/../../../config.php') === true) {
     exit;
 }
 
-echo "before config load";
-
 require_once(__DIR__ . '/../../../config.php');
 global $CFG;
-
-// Maintenance can also be enabled in the database config. Check for it otherwise we'll return a 503 to the heartbeat request
-if (!empty($CFG->maintenance_enabled)) {
-    print "Server is in MAINTENANCE<br>\n";
-    exit;
-} else {
-    echo "not in maintenance";
-}
 
 $status = "";
 

--- a/index.php
+++ b/index.php
@@ -66,10 +66,9 @@ function check_climaintenance($configfile) {
     $content = preg_replace("/;/", ";\n", $content);         // Split up statements, replace ';' with ';\n'
     $content = preg_replace("/^[\s]+/m", "", $content);      // Removes all initial whitespace and newlines.
 
-    //$re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot.
     $re = '/^\$CFG->dataroot\s+=\s+(.*?);/m';  // Lines starting with $CFG->dataroot.
     preg_match($re, $content, $matches);
-    
+
     if (!empty($matches)) {
         // We trust what we found is safe because it was found in the site's config.php
         // This eval makes it so that any use of getenv() or other variables to feed that dataroot variable will be parsed correctly

--- a/index.php
+++ b/index.php
@@ -87,6 +87,12 @@ if (check_climaintenance(__DIR__ . '/../../../config.php') === true) {
 require_once(__DIR__ . '/../../../config.php');
 global $CFG;
 
+// Maintenance can also be enabled in the database config. Check for it otherwise we'll return a 503 to the heartbeat request
+if (!empty($CFG->maintenance_enabled)) {
+    print "Server is in MAINTENANCE<br>\n";
+    exit;
+}
+
 $status = "";
 
 /**

--- a/index.php
+++ b/index.php
@@ -66,10 +66,13 @@ function check_climaintenance($configfile) {
     $content = preg_replace("/;/", ";\n", $content);         // Split up statements, replace ';' with ';\n'
     $content = preg_replace("/^[\s]+/m", "", $content);      // Removes all initial whitespace and newlines.
 
-    $re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot.
+    //$re = '/^\$CFG->dataroot\s+=\s+["\'](.*?)["\'];/m';  // Lines starting with $CFG->dataroot.
+    $re = '/^\$CFG->dataroot\s+=\s+(.*?);/m';  // Lines starting with $CFG->dataroot.
     preg_match($re, $content, $matches);
     
     print_r($matches);
+    $dataroot = $matches[count($matches) - 1];
+    echo "dataroot=".$dataroot;
     
     if (!empty($matches)) {
         $climaintenance = $matches[count($matches) - 1] . '/climaintenance.html';

--- a/index.php
+++ b/index.php
@@ -84,6 +84,8 @@ if (check_climaintenance(__DIR__ . '/../../../config.php') === true) {
     exit;
 }
 
+echo "before config load";
+
 require_once(__DIR__ . '/../../../config.php');
 global $CFG;
 
@@ -91,6 +93,8 @@ global $CFG;
 if (!empty($CFG->maintenance_enabled)) {
     print "Server is in MAINTENANCE<br>\n";
     exit;
+} else {
+    echo "not in maintenance";
 }
 
 $status = "";


### PR DESCRIPTION
Some deployments use a dataroot directive like so in config.php:

$CFG->dataroot  = getenv('MDL_DATAROOT');

However the way the regex was done, it wouldn't detect properly the dataroot and thus wouldn't detect maintenance mode.

This, in turn, allows Moodle to respond the usual 503 error to heartbeat requests, which on some services, cannot be set to mean "healthy". 

As a cascade of events, health-checking services that cannot tolerate 503 as a healthy service will terminate instances that return such an http code. Meaning, all instances will get terminated whenever maintenance mode is activated.

With this fix, we evaluate the $CFG->dataroot line, permitting such getenv scenarios.