### PR TITLE
Fix cron check page when mnet is enabled

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -281,6 +281,7 @@ if ( $maxminsdelay > $options['delayerror'] ) {
 if (class_exists('\core\check\manager')) {
 
     if (isset($CFG->mnet_dispatcher_mode) and $CFG->mnet_dispatcher_mode !== 'off') {
+        // This is a core bug workaround, see MDL-77247 for more details.
         require_once($CFG->dirroot.'/mnet/lib.php');
     }
 

--- a/croncheck.php
+++ b/croncheck.php
@@ -280,6 +280,10 @@ if ( $maxminsdelay > $options['delayerror'] ) {
 // If the Check API from 3.9 exists then call those as well.
 if (class_exists('\core\check\manager')) {
 
+    if (isset($CFG->mnet_dispatcher_mode) and $CFG->mnet_dispatcher_mode !== 'off') {
+        require_once($CFG->dirroot.'/mnet/lib.php');
+    }
+
     $checks = \core\check\manager::get_checks('status');
     $output = '';
     // Should this check block emit as critical?


### PR DESCRIPTION
This is to fix https://github.com/catalyst/moodle-tool_heartbeat/issues/129