### PR TITLE
134 invalid task hardening

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -229,10 +229,11 @@ foreach ($scheduledtasks as $task) {
 
 // Instead of using task API here, we read directly from the database.
 // This stops errors originating from broken tasks, and allows the DB to de-duplicate them.
-$adhoctasks = $DB->get_records_sql("  SELECT classname, COUNT(*) count, MAX(faildelay) faildelay
+$adhoctasks = $DB->get_records_sql("  SELECT classname, COUNT(*) count, MAX(faildelay) faildelay, SUM(faildelay) cfaildelay
                                        FROM {task_adhoc}
                                       WHERE faildelay > 0
-                                   GROUP BY classname");
+                                   GROUP BY classname
+                                   ORDER BY cfaildelay DESC");
 
 foreach ($adhoctasks as $record) {
     // Only add duplicate message if there are more than 1.


### PR DESCRIPTION
Closes #134 

Closes #136 

## Changes
### Removed use of task `\core\task\manager`.
It's much more reliable to just read the data directly from the database.  This is because the manager class can throw errors, or the task class itself can throw them like described in the #134. The manager class also outputs debugging if the task is not found, which pollutes the output (unless we force disable debugging).

Its much simpler and cleaner to just read directly from the DB. We lose the ability to get the scheduled task name, but IMO this is not a big deal since you can just read it from the class.

Using the DB also has the advantage of being able to easily de-dup the tasks (For #136)

### Added try/catch for check API errors

If a check class is broken or throws an exception, now we get a nice error message:

```
CRITICAL: Error scanning checks: coding_exception: Coding error detected, it must be fixed by a programmer: test in /var/www/moodle-311-heartbeat/admin/tool/heartbeat/classes/check/authcheck.php:60
Stack trace:
#0 /var/www/moodle-311-heartbeat/admin/tool/heartbeat/croncheck.php(315): tool_heartbeat\check\authcheck->get_result()
#1 {main}
 (Checked Oct 3 13:42:42)
```
This indicates something went really wrong, since ideally check classes should always be properly linked.

I'm still a little undecided whether to include just the message, or the full error (incl. stacktrace). I leaned towards full error so that you can tell what plugin/code is throwing the error.

## Testing / example:

![image](https://github.com/catalyst/moodle-tool_heartbeat/assets/17095477/569bf4a3-0a81-4d30-afcc-b085eab918c1)
![image](https://github.com/catalyst/moodle-tool_heartbeat/assets/17095477/c0f309d6-f8a5-488a-a66c-b544909ee3dd)

```
CRITICAL: Moodle task faildelay > 600 mins
SCHEDULED TASK: \core\task\cache_cron_task Delay: 86400
ADHOC TASK: \tool_dataprivacy\task\process_data_request_task Delay: 86400  (4 duplicates!!!)
ADHOC TASK: \tool_dataprivacy\task\initiate_data_request_task Delay: 86400 
 (Checked Oct 9 09:39:40)
```
