### PR TITLE
[#144] Remove unnecessary cronlib include

### DIFF
--- a/classes/check/tasklatencycheck.php
+++ b/classes/check/tasklatencycheck.php
@@ -33,9 +33,6 @@ namespace tool_heartbeat\check;
 use core\check\check;
 use core\check\result;
 
-defined('MOODLE_INTERNAL') || die();
-require_once("$CFG->libdir/cronlib.php");
-
 /**
  * Task latency check class.
  *


### PR DESCRIPTION
Closes #144 
Closes #143

Turns out this inclusion was not necessary, since this file does not call any of the functions. 

Removed the lib, and tested locally (still works) and unit tests pass, so confident it was simply accidentally included.