### PR TITLE
147 capture debugging

### DIFF
--- a/croncheck.php
+++ b/croncheck.php
@@ -288,8 +288,8 @@ if (class_exists('\core\check\manager')) {
     try {
         $checks = \core\check\manager::get_checks('status');
     } catch (\Throwable $e) {
-        $critical = true;
-        $output .= "Error scanning checks: {$e}\n";
+        // The check API exploded, so there is no point continuing.
+        send_critical("Error scanning checks: {$e}\n");
     }
 
     // Define a function to get the check result and determine if the error is critical or not.

--- a/croncheck.php
+++ b/croncheck.php
@@ -42,6 +42,11 @@ $legacywarn      = 60 * 2; // Minutes.
 
 // @codingStandardsIgnoreEnd
 
+// Start output buffering. This stops for e.g. debugging messages from breaking the output.
+// When a nagios.php send_* function is called, they will collect the buffer
+// and warn if it is not empty (but do it nicely).
+ob_start();
+
 $dirroot = __DIR__ . '/../../../';
 
 if (isset($argv)) {


### PR DESCRIPTION
Closes #147 

## Changes:

- Captures output buffer during entire script (for e.g. debugging, etc...)
- If when sending a response, the output buffer was not empty then it upgrades any unknown or ok statuses to warning and displays what was captured

Also included is a tiny bugfix related to https://github.com/catalyst/moodle-tool_heartbeat/issues/134:
- caused by `$output` not existing (it's created later), but it was trying to append to it so it threw debugging message. Now it just sends critical (if it breaks here, there is no point continuing and something is very wrong e.g. bad plugin classes)

## Example:
1. Break any task class by changing its name
2. Ensure the adhoc/scheduled tasks are fine, so that the check API block is executed
3. Check croncheck.php:

```
WARNING: MOODLE CRON RUNNING, but there was unexpected output:
 <div class="notifytiny debuggingmessage" data-rel="debugging">Failed to load task: \mod_lti\task\clean_access_tokens<ul style="text-align: left" data-rel="backtrace"><li>line 376 of /lib/classes/task/manager.php: call to debugging()</li><li>line 598 of /lib/classes/task/manager.php: call to core\task\manager::scheduled_task_from_record()</li><li>line 64 of /admin/tool/task/classes/check/maxfaildelay.php: call to core\task\manager::get_all_scheduled_tasks()</li><li>line 301 of /admin/tool/heartbeat/croncheck.php: call to tool_task\check\maxfaildelay->get_result()</li><li>line 347 of /admin/tool/heartbeat/croncheck.php: call to {closure}()</li><li>line ? of unknownfile: call to {closure}()</li><li>line 353 of /admin/tool/heartbeat/croncheck.php: call to array_map()</li></ul></div>

 (Checked Oct 10 12:06:45)
```

Here the `OK: MOODLE CRON RUNNING` got upgraded to `WARNING: MOODLE CRON RUNNING, but there was unexpected output:...`
