### PR TITLE
150 improve consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Failed: database error
 
 ## Application health
 
-This is the croncheck.php - it is mostly, and was originally only around the cron queues, but has grown to cover other aspects.
+Named `croncheck.php` for compatibility with older versions of this plugin, this page executes all `status` check API checks, and shows any that return non-ok results.
 
 It is a nagios compliant checker to see if cron or any individual tasks are failing, with configurable thresholds
 
@@ -81,13 +81,6 @@ Or can be run as a CLI in which case it will return in the format expected by Na
 ```
 sudo -u www-data php /var/www/moodle/admin/tool/heartbeat/croncheck.php
 ```
-
-The various thresholds can be configured with query params or cli args see this for details:
-
-```
-php croncheck.php -h
-```
-
 
 ## Failed login detection
 
@@ -111,10 +104,16 @@ php loginchecker.php -h
 
 # Branches
 
+| Branch      | Version |
+| ----------- | ----------- |
+| master      | Moodle 2.7 + |
+| MOODLE_39_STABLE   | Moodle 3.9 + |
+
 The master branch is always stable and should retain very deep support for old Totara's and Moodle's back to Moodle 2.7
 
 For this reason we will continue to support php5 for some time.
 
+The MOODLE_39_STABLE branch uses the [Check API](https://moodledev.io/docs/apis/subsystems/check) exclusively.
 
 # Installation
 

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -1,0 +1,127 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_heartbeat\check;
+
+use core\check\check;
+use core\check\result;
+
+/**
+ * Task fail delay check
+ *
+ * This is very similar to the core tool_task::maxfaildelay check, except the output aggregates the number
+ * of each task, so if you have thousands of a task failing it does not spam the output.
+ *
+ * @package    tool_heartbeat
+ * @copyright  2023 Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class failingtaskcheck extends check {
+
+    /** @var int $warnthreshold Threshold in minutes after which should warn about tasks failing **/
+    public $warnthreshold = 60;
+
+    /** @var int $errorthreshold Threshold in minutes after which should error about tasks failing **/
+    public $errorthreshold = 600;
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        $this->id = 'cronfailingtasks';
+        $this->name = get_string('checkfailingtaskcheck', 'tool_heartbeat');
+
+        $this->actionlink = new \action_link(
+            new \moodle_url('/admin/tasklogs.php'),
+            get_string('tasklogs', 'tool_task'));
+    }
+
+    /**
+     * Return result
+     * @return result
+     */
+    public function get_result() : result {
+        global $DB;
+
+        $taskoutputs = [];
+
+        // Instead of using task API here, we read directly from the database.
+        // This stops errors originating from broken tasks.
+        $scheduledtasks = $DB->get_records_sql("SELECT * FROM {task_scheduled} WHERE faildelay > 0 AND disabled = 0");
+
+        foreach ($scheduledtasks as $task) {
+            $taskoutputs[] = "SCHEDULED TASK: {$task->classname} Delay: {$task->faildelay}\n";
+        }
+
+        // Instead of using task API here, we read directly from the database.
+        // This stops errors originating from broken tasks, and allows the DB to de-duplicate them.
+        $adhoctasks = $DB->get_records_sql("  SELECT classname, COUNT(*) count, MAX(faildelay) faildelay, SUM(faildelay) cfaildelay
+                                               FROM {task_adhoc}
+                                              WHERE faildelay > 0
+                                           GROUP BY classname
+                                           ORDER BY cfaildelay DESC");
+
+        foreach ($adhoctasks as $record) {
+            // Only add duplicate message if there are more than 1.
+            $duplicatemsg = $record->count > 1 ? " ({$record->count} duplicates!!!)" : '';
+            $taskoutputs[] = "ADHOC TASK: {$record->classname} Delay: {$record->faildelay} {$duplicatemsg}\n";
+        }
+
+        // Find the largest faildelay out of both adhoc and scheduled tasks.
+        $alldelays = array_merge(array_column($adhoctasks, 'faildelay'), array_column($scheduledtasks, 'faildelay'));
+        $maxdelaymins = !empty($alldelays) ? max($alldelays) / 60 : 0;
+
+        // Define a simple function to work out what the message should be based on the task outputs.
+        // Returns the [$summary, $details].
+        $taskoutputfn = function($faildelaymins) use ($taskoutputs) {
+            $count = count($taskoutputs);
+
+            if ($count == 1) {
+                // Only a single task is failing, so put it at the top level.
+                return [$taskoutputs[0], ''];
+            }
+
+            if ($count > 1) {
+                // More than 1, add a message at the start that indicates how many.
+                return ["{$count} Moodle tasks reported errors, maximum faildelay > {$faildelaymins} mins", implode("", $taskoutputs)];
+            }
+
+            // There are 0 tasks are failing, default to nothing.
+            return ['', ''];
+        };
+
+        // Default to ok.
+        $status = result::OK;
+        $delay = 0;
+
+        // Check if warn - if so then upgrade to warn.
+        if ($maxdelaymins > $this->warnthreshold) {
+            $status = result::WARNING;
+            $delay = $this->warnthreshold;
+        }
+
+        // Check if error - if so then upgrade to error.
+        if ($maxdelaymins > $this->errorthreshold) {
+            $status = result::ERROR;
+            $delay = $this->errorthreshold;
+        }
+
+        list($summary, $details) = $taskoutputfn($delay);
+
+        return new result($status, nl2br($summary), nl2br($details));
+
+    }
+}

--- a/classes/checker.php
+++ b/classes/checker.php
@@ -1,0 +1,301 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_heartbeat;
+
+use core\check\check;
+use core\check\result;
+use Throwable;
+
+/**
+ * Check API checker class
+ *
+ * Processes check API results and returns them in a nice format for nagios output.
+ *
+ * @package   tool_heartbeat
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2023, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class checker {
+    /** @var array Nagios level prefixes **/
+    public const NAGIOS_PREFIXES = [
+        0 => "OK",
+        1 => "WARNING",
+        2 => "CRITICAL",
+        3 => "UNKNOWN",
+    ];
+
+    /**
+     * Returns an array of check API messages.
+     * If exceptions are thrown, they are caught and returned as result messages as well.
+     * Note - OK results are not returned.
+     *
+     * @return array array of resultmessage objects
+     */
+    public static function get_check_messages(): array {
+        // First try to get the checks, if this fails return a critical message (code is very broken).
+        $checks = [];
+
+        try {
+            $checks = \core\check\manager::get_checks('status');
+        } catch (Throwable $e) {
+            return [self::exception_to_message("Error getting checks: ", $e)];
+        }
+
+        // Remove any supressed checks from the list.
+        $checks = array_filter($checks, function($check) {
+            return !in_array(get_class($check), self::supressed_checks());
+        });
+
+        // Execute each check and store their messages.
+        $messages = [];
+
+        foreach ($checks as $check) {
+            try {
+                $messages[] = self::process_check_and_get_result($check);
+            } catch (Throwable $e) {
+                $messages[] = self::exception_to_message("Error processing check " . $check->get_ref() . ": ", $e);
+            }
+        }
+
+        // Add any output buffer message.
+        $messages[] = self::get_ob_message();
+
+        // Filter out any OK messages, we don't care about these.
+        $messages = array_filter($messages, function($m) {
+            return $m->level != resultmessage::LEVEL_OK;
+        });
+
+        return $messages;
+    }
+
+    /**
+     * Closes the output buffering, and if anything was outputted, a warning resultmessage is returned
+     * @return resultmessage
+     */
+    private static function get_ob_message(): resultmessage {
+        $contents = ob_get_clean() ?: '';
+
+        // Default to OK.
+        $res = new resultmessage();
+        $res->level = resultmessage::LEVEL_OK;
+        $res->title = 'Output buffering: No output buffered';
+        $res->message = 'No output buffered';
+
+        if (!empty($contents)) {
+            $res->level = resultmessage::LEVEL_WARN;
+            $res->title = "Output buffering: Unexpected output";
+            $res->message = $contents;
+        }
+
+        // Process these using the HTML cleaning function.
+        list($title, $message) = self::process_title_and_message($res->title, $res->message, "");
+        $res->title = $title;
+        $res->message = $message;
+
+        return $res;
+    }
+
+    /**
+     * Turns the given exception into a warning resultmessage.
+     * @param string $prefix
+     * @param Throwable $e
+     * @return resultmessage
+     */
+    private static function exception_to_message(string $prefix, Throwable $e): resultmessage {
+        $res = new resultmessage();
+        $res->level = resultmessage::LEVEL_WARN;
+        $res->title = $prefix . $e->getMessage();
+        $res->message = (string) $e;
+        return $res;
+    }
+
+    /**
+     * Processes the check and maps its result and status to a resultmessage.
+     * @param check $check
+     * @return resultmessage
+     */
+    private static function process_check_and_get_result(check $check): resultmessage {
+        $res = new resultmessage();
+
+        $checkresult = $check->get_result();
+
+        // Map check result to nagios level.
+        $map = [
+            result::OK => resultmessage::LEVEL_OK,
+            result::NA => resultmessage::LEVEL_OK,
+            result::WARNING => resultmessage::LEVEL_WARN,
+            result::CRITICAL => resultmessage::LEVEL_CRITICAL,
+            result::ERROR => resultmessage::LEVEL_CRITICAL,
+            result::UNKNOWN => resultmessage::LEVEL_UNKNOWN,
+        ];
+
+        // Get the level, or default to unknown.
+        $status = $checkresult->get_status();
+        $res->level = isset($map[$status]) ? $map[$status] : resultmessage::LEVEL_UNKNOWN;
+
+        list($title, $message) = self::process_title_and_message($check->get_name(), $checkresult->get_summary(),
+            $checkresult->get_details());
+        $res->title = $title;
+        $res->message = $message;
+
+        return $res;
+    }
+
+    /**
+     * Parses, cleans and sets up the correct output.
+     * @param string $title
+     * @param string $summary
+     * @param string $details
+     * @return array array of [$title, $message]
+     */
+    private static function process_title_and_message(string $title, string $summary, string $details): array {
+        // Strip tags from summary and details.
+        $summary = self::clean_text($summary);
+        $details = self::clean_text($details);
+
+        // Get all the lines of the message.
+        $messagelines = explode("\n", $summary);
+        $messagelines = array_merge($messagelines, explode("\n", $details));
+
+        // Clean each one.
+        $messagelines = array_map(function($line) {
+            return self::clean_text($line);
+        }, $messagelines);
+
+        // Remove empty lines.
+        $messagelines = array_filter($messagelines);
+
+        // Use the first line in the title.
+        $title .= ": " . array_shift($messagelines);
+
+        // Use the rest in the message.
+        $message = implode("\n", $messagelines);
+
+        return [$title, $message];
+    }
+
+    /**
+     * Cleans the text ready for output.
+     * @param string $text
+     * @return string
+     */
+    private static function clean_text(string $text): string {
+        // Convert any line breaks to newlines.
+        $text = str_replace("<br />", "\n", $text);
+        $text = str_replace("<br>", "\n", $text);
+
+        // Strip tags.
+        $text = strip_tags($text);
+
+        // Clean any pipe characters from the $msg. This is because pipe characters
+        // separate Nagios performance data from log data.
+        // They are replaced with a unicode lookalike.
+        // https://www.compart.com/en/unicode/U+FF5C .
+        $text = str_replace("|", "｜", $text);
+
+        // Strip extra newlines.
+        $text = trim($text);
+
+        return $text;
+    }
+
+    /**
+     * From an array of resultmessage, determines the highest nagios level.
+     * Note, it considers UNKNOWN to be less than CRITICAL or WARNING.
+     *
+     * @param array $messages array of resultmessage objects
+     * @return int the calculated nagios level
+     */
+    public static function determine_nagios_level(array $messages): int {
+        // Find the highest level.
+        $levels = array_column($messages, "level");
+
+        // Add a default "OK" in case no messages were returned.
+        $levels[] = resultmessage::LEVEL_OK;
+
+        $hasunknown = in_array(resultmessage::LEVEL_UNKNOWN, $levels);
+
+        // Remove unknowns.
+        $levels = array_filter($levels, function($l) {
+            return $l != resultmessage::LEVEL_UNKNOWN;
+        });
+
+        $highestwithoutunknown = max($levels);
+
+        // If highest was OK but it had an UNKNOWN, return UNKNOWN.
+        // This stops UNKNOWN from masking WARNING or CRITICAL.
+        if ($highestwithoutunknown == resultmessage::LEVEL_OK && $hasunknown) {
+            return resultmessage::LEVEL_UNKNOWN;
+        }
+
+        // Else return the highest.
+        return $highestwithoutunknown;
+    }
+
+    /**
+     * Creates a summary from the given messages.
+     * If there are no messages or only OK, OK is returned.
+     * If there is a single message, its details are returned.
+     * If there are multiple messages, the levels are aggregated and turned into a summary.
+     *
+     * @param array $messages array of resultmessage objects
+     * @return string
+     */
+    public static function create_summary(array $messages): string {
+        // Filter out any OK messages.
+        // Usually they are filtered out already, but in case they aren't.
+        $messages = array_filter($messages, function($m) {
+            return $m->level != resultmessage::LEVEL_OK;
+        });
+
+        // If no messages, return OK.
+        if (count($messages) == 0) {
+            return "OK";
+        }
+
+        // If only one message, use it as the top level.
+        if (count($messages) == 1) {
+            return self::clean_text(current($messages)->title);
+        }
+
+        // Otherwise count how many of each level.
+        $counts = array_count_values(array_column($messages, 'level'));
+
+        $countswithprefixes = [];
+        foreach ($counts as $level => $occurrences) {
+                $prefix = self::NAGIOS_PREFIXES[$level];
+             $countswithprefixes[] = "{$occurrences} {$prefix}";
+        }
+
+        return "Multiple problems detected: " . implode(", ", $countswithprefixes);
+    }
+
+    /**
+     * Stores any checks that are suppressed/ignored by this class.
+     * @return array array of class name strings of checks to ignore
+     */
+    private static function supressed_checks(): array {
+        return [
+            // These two supressed and replaced by a more detailed/useful version in this plugin.
+            // See failingtaskcheck.php.
+            \tool_task\check\maxfaildelay::class,
+            \tool_task\check\adhocqueue::class,
+        ];
+    }
+}
+

--- a/classes/resultmessage.php
+++ b/classes/resultmessage.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_heartbeat;
+
+/**
+ * A data-only class for holding a message about a result from a check API class.
+ *
+ * @package   tool_heartbeat
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2023, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class resultmessage {
+    /** @var int OK level **/
+    public const LEVEL_OK = 0;
+
+    /** @var int WARN level **/
+    public const LEVEL_WARN = 1;
+
+    /** @var int CRITICAL level **/
+    public const LEVEL_CRITICAL = 2;
+
+    /** @var int UNKNOWN level **/
+    public const LEVEL_UNKNOWN = 3;
+
+    /** @var int $level The level of this message **/
+    public $level = self::LEVEL_UNKNOWN;
+
+    /** @var string $title Title of the message **/
+    public $title = '';
+
+    /** @var string $message Details of this message **/
+    public $message = '';
+}
+

--- a/lang/en/tool_heartbeat.php
+++ b/lang/en/tool_heartbeat.php
@@ -79,6 +79,8 @@ $string['latencyruntime'] = 'Task {$a->task} was last run with a runtime longer 
 $string['checktasklatencycheck'] = 'Task latency check';
 $string['taskconfigbad'] = 'Bad configurations {$a}';
 $string['tasklatencyok'] = 'Task latency OK.';
+$string['checkfailingtaskcheck'] = 'Failing tasks';
+
 /*
  * Privacy provider (GDPR)
  */

--- a/lib.php
+++ b/lib.php
@@ -31,6 +31,7 @@ function tool_heartbeat_status_checks() {
         new \tool_heartbeat\check\authcheck(),
         new \tool_heartbeat\check\logstorecheck(),
         new \tool_heartbeat\check\tasklatencycheck(),
+        new \tool_heartbeat\check\failingtaskcheck(),
     ];
 }
 

--- a/templates/resultmessage.mustache
+++ b/templates/resultmessage.mustache
@@ -1,0 +1,40 @@
+
+{{!
+    This file is part of Moodle - https://moodle.org/
+    
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+    
+    You should have received a copy of the GNU General Public License
+    along with Moodle. If not, see
+    <http: //www.gnu.org/licenses />.
+    }}
+    {{!
+        @template tool_heartbeat/resultmessage
+        
+        Template by JS to render output of result report getting (loading, url, error)
+        
+        Classes required for JS:
+        * none
+        
+        Context variables required for this template:
+        * none
+        
+        Example context (json):
+        {  
+            "prefix": "CRTIICAL",
+            "title": "Something broke",
+            "message": "Some more details"
+        }
+    }}
+
+* {{prefix}} {{title}}
+{{message}}
+

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -1,0 +1,152 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_heartbeat;
+
+/**
+ * Test class for tool_heartbeat\checker
+ *
+ * @package   tool_heartbeat
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2023, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class checker_test extends \advanced_testcase {
+    /**
+     * Tests get_check_messages function
+     */
+    public function test_get_check_messages() {
+        // Need to start output buffering, since get_check_messages closes it.
+        ob_start();
+
+        // Check API modifies DB state.
+        $this->resetAfterTest(true);
+
+        // Just test that the check API is working, and this returns some checks (for example the ones included with this plugin).
+        $checks = checker::get_check_messages();
+        $this->assertNotEmpty($checks);
+    }
+
+    /**
+     * Provides values to determine_nagios_level test
+     * @return array
+     */
+    public static function determine_nagios_level_provider(): array {
+        return [
+            'no messages' => [
+                'levels' => [],
+                'nagioslevel' => resultmessage::LEVEL_OK,
+            ],
+            'one OK message' => [
+                'levels' => [resultmessage::LEVEL_OK],
+                'nagioslevel' => resultmessage::LEVEL_OK,
+            ],
+            'one UNKNOWN message' => [
+                'levels' => [resultmessage::LEVEL_UNKNOWN],
+                'nagioslevel' => resultmessage::LEVEL_UNKNOWN,
+            ],
+            'one UNKNOWN and one OK' => [
+                'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_OK],
+                'nagioslevel' => resultmessage::LEVEL_UNKNOWN,
+            ],
+            'one UNKNOWN and one WARNING' => [
+                'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_WARN],
+                'nagioslevel' => resultmessage::LEVEL_WARN,
+            ],
+            'one UNKNOWN and on CRITICAL' => [
+                'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_CRITICAL],
+                'nagioslevel' => resultmessage::LEVEL_CRITICAL,
+            ],
+        ];
+    }
+
+    /**
+     * Tests determine_nagios_level function
+     * @param array $levels
+     * @param int $expectedlevel
+     * @dataProvider determine_nagios_level_provider
+     */
+    public function test_determine_nagios_level(array $levels, int $expectedlevel) {
+        // Generate a series of dummy messages with the given levels.
+        $messages = array_map(function($level) {
+            $msg = new resultmessage();
+            $msg->level = $level;
+            return $msg;
+        }, $levels);
+
+        // Confirm the correct level outputted.
+        $level = checker::determine_nagios_level($messages);
+        $this->assertEquals($expectedlevel, $level);
+    }
+
+    /**
+     * Provides values to test_create_summary test
+     * @return array
+     */
+    public static function create_summary_provider(): array {
+
+        $warnmsg = new resultmessage();
+        $warnmsg->level = resultmessage::LEVEL_WARN;
+        $warnmsg->title = "test WARN title";
+
+        $okmsg = new resultmessage();
+        $okmsg->level = resultmessage::LEVEL_OK;
+        $okmsg->title = "test OK title";
+
+        $criticalmsg = new resultmessage();
+        $criticalmsg->level = resultmessage::LEVEL_CRITICAL;
+        $criticalmsg->title = "test CRITICAL title";
+
+        // Pipes should be cleaned from output and replaced with [pipe]
+        $criticalwithpipemsg = new resultmessage();
+        $criticalwithpipemsg->level = resultmessage::LEVEL_CRITICAL;
+        $criticalwithpipemsg->title = "test CRITICAL title |";
+
+        return [
+            'no messages (no message displayed)' => [
+                'messages' => [],
+                'expectedsummary' => "OK",
+            ],
+            'only OK (no message displayed)' => [
+                'messages' => [$okmsg],
+                'expectedsummary' => "OK",
+            ],
+            'only WARNING (shows error in top level)' => [
+                'messages' => [$warnmsg],
+                'expectedsummary' => $warnmsg->title,
+            ],
+            'mix of warning levels (shows summary of levels without including OK)' => [
+                'messages' => [$warnmsg, $okmsg, $criticalmsg],
+                'expectedsummary' => "Multiple problems detected: 1 WARNING, 1 CRITICAL",
+            ],
+            'pipe char in output is cleaned' => [
+                'messages' => [$criticalwithpipemsg],
+                'expectedsummary' => str_replace('|', '｜', $criticalwithpipemsg->title)
+            ]
+        ];
+    }
+
+    /**
+     * Tests create_summary function
+     * @param array $messages
+     * @param string $expectedsummary
+     * @dataProvider create_summary_provider
+     */
+    public function test_create_summary(array $messages, string $expectedsummary) {
+        $summary = checker::create_summary($messages);
+        $this->assertEquals($expectedsummary, $summary);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2023101100;
 $plugin->release   = 2023101100; // Match release exactly to version.
-$plugin->requires  = 2012120311; // Deep support going back to 2.4.
-$plugin->supported = [24, 401];
+$plugin->requires  = 2020061500; // Support for 3.9 and above, due to the Check API.
+$plugin->supported = [39, 401];
 $plugin->component = 'tool_heartbeat';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Closes #150 

### Refactored `croncheck.php`

This page now ONLY displays the results of check API classes. This page works still either via web or CLI, however the configurable delays have been removed from this page, since those are handled by the check API class directly.

### Added new check class `failingtaskcheck.php`
While core does have an adhoc/scheduled task check, it has a few limitations:
1) It uses the task api which can explode if a bad task is installed masking failed tasks
2) It does not aggregate / deduplicate tasks leading to a big list if you have tons of a single task failing

So instead, I copied more or less the same code from https://github.com/catalyst/moodle-tool_heartbeat/pull/145 and put it inside a check class. I then suppress the core adhoc task checks from this page since all the information is now included nicely in the `failingtaskcheck.php` class.

### Example output: 

**No check failing**
```
OK: OK
(Checked Monday, 16 October 2023, 4:09 PM) 
```

**Single check failing (Shows error in top level)** (note for consistency, the message still shows in the list so it gets shown twice)
```
WARNING: Cron running: The admin/cron.php script has not been run for 15 mins 7 secs and should run every 1 min.
* WARNING Cron running: The admin/cron.php script has not been run for 15 mins 7 secs and should run every 1 min.
  15 mins 7 secs

(Checked Monday, 16 October 2023, 4:08 PM) 
```

**Multiple checks failing of different levels (shows summary of levels)**
```
CRITICAL: Multiple problems detected: 1 CRITICAL, 1 WARNING
* CRITICAL Failing tasks: 4 Moodle tasks reported errors, maximum faildelay > 600 mins
  SCHEDULED TASK: \core\task\h5p_get_content_types_task Delay: 86400
  ADHOC TASK: \tool_dataprivacy\task\process_data_request_task Delay: 86400 (13 duplicates!!!)
  ADHOC TASK: \tool_dataprivacy\task\initiate_data_request_task Delay: 86400
  ADHOC TASK: \core\task\build_installed_themes_task Delay: 86400

* WARNING Cron running: The admin/cron.php script has not been run for 3 mins 5 secs and should run every 1 min.
  3 mins 5 secs

(Checked Monday, 16 October 2023, 3:49 PM) 
```

** Debugging outputted and captured **
```
WARNING: Multiple problems detected: 2 WARNING
* WARNING Cron running: The admin/cron.php script has not been run for 13 mins 26 secs and should run every 1 min.
  13 mins 26 secs

* WARNING Output buffering: Unexpected output: testline 74 of /admin/tool/heartbeat/classes/checker.php: call to debugging()line 56 of /admin/tool/heartbeat/sitecheck.php: call to tool_heartbeat\checker::get_check_messages()
  

(Checked Monday, 16 October 2023, 4:06 PM) 
```

To Do:
- [x] Adhoc task + scheduled task - check output is useful
- [x] Debugging outputted - ensure captured by output buffer
- [x] Ci passes
- [x] Update README