### PR TITLE
[#165] Add cachecheck logging

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -16,6 +16,8 @@
 
 namespace tool_heartbeat;
 
+use Throwable;
+
 /**
  * General functions for use with heartbeat.
  *
@@ -59,4 +61,44 @@ class lib {
             send_unknown($msg);
         }
     }
+
+    /**
+     * Records that the cache was pinged. This is useful for cache debugging.
+     * @param int $previousincache
+     * @param int $previousindb
+     * @param int $newvalueset the value that the cache was set to
+     * @param int $readbackvalue the value read back from the cache immediately after it was set.
+     * @param string $where cron or web
+     */
+    public static function record_cache_pinged(int $previousincache, int $previousindb, int $newvalueset, int $readbackvalue,
+        string $where) {
+        $details = [
+                'previousvalueindb' => $previousindb,
+                'previousvalueincache' => $previousincache,
+                'newvalueincache' => $newvalueset,
+                'cachedvalueimmediatelyafterwrite' => $readbackvalue,
+                'where' => $where,
+        ];
+        // @codingStandardsIgnoreStart
+        error_log("Heartbeat cache was updated/pinged: " . json_encode($details));
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * Records that the cache was checked. This is used for debugging cache mismatches
+     * @param int $valueincache
+     * @param int $valueindb
+     * @param string $where web or cron
+     */
+    public static function record_cache_checked(int $valueincache, int $valueindb, string $where) {
+        $details = [
+                'valueindb' => $valueindb,
+                'valueincache' => $valueincache,
+                'where' => $where,
+        ];
+        // @codingStandardsIgnoreStart
+        error_log("Heartbeat cache was checked: " . json_encode($details));
+        // @codingStandardsIgnoreEnd
+    }
 }
+

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 $tasks = [
     [
         'classname' => 'tool_heartbeat\task\cachecheck',
-        'minute' => '*',
+        'minute' => '0',
         'hour' => '*/8',
         'day' => '*',
         'dayofweek' => '*',

--- a/lang/en/tool_heartbeat.php
+++ b/lang/en/tool_heartbeat.php
@@ -85,6 +85,13 @@ $string['latencyruntime'] = 'Task {$a->task} was last run with a runtime longer 
 $string['checktasklatencycheck'] = 'Task latency check';
 $string['taskconfigbad'] = 'Bad configurations {$a}';
 $string['tasklatencyok'] = 'Task latency OK.';
+
+$string['settings:cachecheckheading'] = 'Cache consistency check';
+$string['settings:shouldlogcacheping:heading'] = 'Log cache ping';
+$string['settings:shouldlogcacheping:desc'] = 'If enabled, whenever the cache ping is updated (usually once every 24 hrs), a <code>cache_ping</code> event will be triggered';
+$string['settings:shouldlogcachecheck:heading'] = 'Log cache check';
+$string['settings:shouldlogcachecheck:desc'] = 'If enabled, whenever the cache ping is checked (whenever the <code>cachecheck</code> check is executed) a <code>cache_check</code> event will be triggered';
+
 /*
  * Privacy provider (GDPR)
  */

--- a/settings.php
+++ b/settings.php
@@ -95,5 +95,27 @@ if ($hassiteconfig) {
         $settings->add(new admin_setting_configtextarea('tool_heartbeat/tasklatencymonitoring',
                 get_string('tasklatencymonitoring', 'tool_heartbeat'),
                 get_string('tasklatencymonitoring_desc', 'tool_heartbeat', $example), '', PARAM_TEXT));
+
+        // Cache consistency check settings.
+        $settings->add(new admin_setting_heading('tool_heartbeat/cachechecksettings',
+            get_string('settings:cachecheckheading', 'tool_heartbeat'),
+            ''
+        ));
+
+        $settings->add(new admin_setting_configcheckbox('tool_heartbeat/shouldlogcacheping',
+            get_string('settings:shouldlogcacheping:heading', 'tool_heartbeat'),
+            get_string('settings:shouldlogcacheping:desc', 'tool_heartbeat'),
+            // Since pinging only happens usually once every 24 hrs, we default this on as it is quite lightweight.
+            1
+        ));
+
+        $settings->add(new admin_setting_configcheckbox('tool_heartbeat/shouldlogcachecheck',
+            get_string('settings:shouldlogcachecheck:heading', 'tool_heartbeat'),
+            get_string('settings:shouldlogcachecheck:desc', 'tool_heartbeat'),
+            // This happens every time the check api cachecheck is called, which is a lot more often than pinging.
+            // For e.g. with external monitoring, it could be once or more per minute.
+            // So its defaulted to off unless turned on for specific debugging.
+            0
+        ));
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023102400;
-$plugin->release   = 2023102400; // Match release exactly to version.
+$plugin->version   = 2023102401;
+$plugin->release   = 2023102401; // Match release exactly to version.
 $plugin->requires  = 2012120311; // Deep support going back to 2.4.
 $plugin->supported = [24, 401];
 $plugin->component = 'tool_heartbeat';


### PR DESCRIPTION
Closes #165 
Closes #168 

## Changes:
- 2 new events:
    - `cache_check`: whenever the cachecheck check api is run.
    - `cache_ping`: whenever a new value is written to the cache
- Each one records details e.g. what the cached value was, what the db value was, and for cache_ping, what the value it just wrote to the cache was. <strike>It also logs more data e.g. site identifier and session redis prefix so it might be obvious if these are broken or not correct to the site.</strike>
- Settings to turn each of these on / off since they are debugging tools so don't always need to be turned on.
- Also a tiny bugfix for cachecheck cron to only run once every 8 hrs, instead of every min in the 8th hr

<strike>I'm still a bit undecided whether site identifier or session redis prexis is useful. For e.g. if you had a cache issue such as another site (site B) using the same prefix, these logs would be written on Site Bs logs but would have Site A's prefix. But if you only knew about site A, you would have no idea how to find site B.

Since event logs are logged, it could be possible to work this out if you grepped across all the site logs for a particular prefix and see what sites are putting those cachecheck/ping logs out.</strike>

### TODO after merging:

- [ ] Cherry pick to `MOODLE_39_STABLE` -> https://github.com/catalyst/moodle-tool_heartbeat/pull/167

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)

