### PR TITLE
WR #432782: Moodle 4.4 fixing heartbeat causing behat to fail

### DIFF
--- a/classes/check/cachecheck.php
+++ b/classes/check/cachecheck.php
@@ -180,7 +180,10 @@ class cachecheck extends check {
             // This should help detect any cache replication delays.
             $readbackvalue = self::get_cache_ping_value($type);
 
-            debugging("\nHEARTBEAT doing {$type} ping\n", DEBUG_DEVELOPER);
+            // Checking if behat site is running.
+            if (!(defined('BEHAT_SITE_RUNNING') && BEHAT_SITE_RUNNING)) {
+                debugging("\nHEARTBEAT doing {$type} ping\n", DEBUG_DEVELOPER);
+            }
 
             if (get_config('tool_heartbeat', 'shouldlogcacheping')) {
                 lib::record_cache_pinged($currentcache, $currentdb, $time, $readbackvalue, $type);


### PR DESCRIPTION
For some reason a debugging message was causing all the behat tests to fail when heartbeat was running on the site so I added a check to not run the debugging message when a behat test is running.


### Pull request checks
- [ Y ] I have checked the version numbers are correct as per the [README](./README.md#branches)
