### PR TITLE
bugfix: add info check result mapping

### DIFF
--- a/classes/checker.php
+++ b/classes/checker.php
@@ -135,6 +135,7 @@ class checker {
         // Map check result to nagios level.
         $map = [
             result::OK => resultmessage::LEVEL_OK,
+            result::INFO => resultmessage::LEVEL_OK,
             result::NA => resultmessage::LEVEL_OK,
             result::WARNING => resultmessage::LEVEL_WARN,
             result::CRITICAL => resultmessage::LEVEL_CRITICAL,


### PR DESCRIPTION
**Issue**
- Discovered that `result::INFO` was not being mapped and hence would output as 'UNKNOWN' which is considered bad, when info isn't actually a bad thing.

**Fix**
- Added info to the mapping

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)
