### PR TITLE
Mutes should only lower level #196

### DIFF
--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -123,7 +123,7 @@ class failingtaskcheck extends check {
      * @return array of failing tasks
      */
     public static function get_failing_tasks(): array {
-        GLOBAL $DB;
+        global $DB;
         $tasks = [];
 
         // Instead of using task API here, we read directly from the database.


### PR DESCRIPTION
Closes #196 

I've leaned on the side of caution and haven't marked the override as resolved as some checks may fail sporadically - but ideally we would be cleaning up the ones that are fully resolved. 

### Pull request checks
- [Y] I have checked the version numbers are correct as per the [README](./README.md#branches)
