### PR TITLE
Add max warning level configuration to faildelay check

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $CFG->tool_heartbeat_check_defaults = [
 ];
 ```
 
-Each item is tested via `preg_match` against the globally unique check reference string for the check, if it matches, the max warning level configuration is applied, this applies each item in the array from first to last, so if a check matches more than once, the value that is latest in the array is used, this allows setting more broad defaults and then increasing specififity for specific checks to allow them to override the broader defaults.
+Each item is tested via `preg_match` against the globally unique check reference string for the check, if it matches, the max warning level configuration is applied, this applies each item in the array from first to last, so if a check matches more than once, the value that is latest in the array is used, this allows setting more broad defaults and then increasing specificity for specific checks to allow them to override the broader defaults.
 
 
 

--- a/README.md
+++ b/README.md
@@ -143,24 +143,31 @@ http://moodle.local/admin/settings.php?section=tool_heartbeat
 * By default in a new install this is set to 'error'. This is done intertionally so that you know your monitoring is wired up correctly end to end. You should see you monitoring raise an alert which tells you that it is a test and links to the admin setting to turn it into normal monitoring mode.
 * Optionaly lock down the endpoints by IP
 
-## Task fail delay maximum alerting level configuration
-This plugin allows configuring maximum permitted check level for faildelay checks for tasks.
+## Check maximum alerting level configuration
+This plugin allows configuring maximum permitted alerting level of tasks in the config.php
 
-You can provide a default for all tasks, as well as per task configurations that have precedence over the task default.
+This is supplied as list of regex tests and their associated configuration array.
 
-The configuration is stored in the site config.php under the config setting $CFG->tool_heartbeat_tasks
+The configuration is stored in the site config.php under the config setting $CFG->tool_heartbeat_check_defaults
 
 This should be an array with a form like the following
-```
-$CFG->tool_heartbeat_tasks = [
-	'*' => [
-		'maxfaildelaylevel' => 'warning',
-	],
-	'\core\task\delete_unconfirmed_users_task' => [
-		'maxfaildelaylevel' => 'critical',
-	],
+```php
+$CFG->tool_heartbeat_check_defaults = [
+    '.+_task_.+' => [
+        'maxwarninglevel' => 'info',
+    ],
+    'core_task_tag_cron_task' => [
+        'maxwarninglevel' => 'critical',
+    ],
+    'tool_task_.*' => [
+        'maxwarninglevel' => 'critical',
+    ],
 ];
 ```
+
+Each item is tested via `preg_match` against the globally unique check reference string for the check, if it matches, the max warning level configuration is applied, this applies each item in the array from first to last, so if a check matches more than once, the value that is latest in the array is used, this allows setting more broad defaults and then increasing specififity for specific checks to allow them to override the broader defaults.
+
+
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,24 @@ http://moodle.local/admin/settings.php?section=tool_heartbeat
 * By default in a new install this is set to 'error'. This is done intertionally so that you know your monitoring is wired up correctly end to end. You should see you monitoring raise an alert which tells you that it is a test and links to the admin setting to turn it into normal monitoring mode.
 * Optionaly lock down the endpoints by IP
 
+## Task fail delay maximum alerting level configuration
+This plugin allows configuring maximum permitted check level for faildelay checks for tasks.
+
+You can provide a default for all tasks, as well as per task configurations that have precedence over the task default.
+
+The configuration is stored in the site config.php under the config setting $CFG->tool_heartbeat_tasks
+
+This should be an array with a form like the following
+```
+$CFG->tool_heartbeat_tasks = [
+	'*' => [
+		'maxfaildelaylevel' => 'warning',
+	],
+	'\core\task\delete_unconfirmed_users_task' => [
+		'maxfaildelaylevel' => 'critical',
+	],
+];
+```
 
 # Testing
 

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_heartbeat\check;
-
+use tool_heartbeat\checker;
 use core\check\check;
 use core\check\result;
 
@@ -97,23 +97,6 @@ class failingtaskcheck extends check {
         return new result($status, $this->task->message, '');
     }
 
-    /**
-     * Returns each moodle core result error status as a map of string => integer value, this is used for sorting
-     * alerts when determining the maximum allowed level.
-     *
-     * @return array{na: int, ok: int, info: int, unknown: int, warning: int, error: int, critical: int}
-     */
-    public static function get_integer_values_array() {
-        return array(
-            result::NA => 0,
-            result::OK => 1,
-            result::INFO => 2,
-            result::UNKNOWN => 3,
-            result::WARNING => 4,
-            result::ERROR => 5,
-            result::CRITICAL => 6,
-        );
-    }
 
     /**
      * Look at the task warning configuration and apply the global default, or if a specific task
@@ -140,7 +123,7 @@ class failingtaskcheck extends check {
             $max = $this->config[$this->task->classname]['maxfaildelaylevel'];
         }
         // Get a map of result string to integers representing their "order level".
-        $map = self::get_integer_values_array();
+        $map = checker::RESULT_MAPPING;
         // Get the order value of each status.
         $maxint = $map[$max];
         $realint = $map[$status];
@@ -184,7 +167,7 @@ class failingtaskcheck extends check {
      * @return array of failing tasks
      */
     public static function get_failing_tasks(): array {
-        GLOBAL $DB, $CFG;
+        global $DB, $CFG;
         $tasks = [];
 
         // Instead of using task API here, we read directly from the database.

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_heartbeat\check;
+
 use core\check\check;
 use core\check\result;
 
@@ -38,7 +39,6 @@ class failingtaskcheck extends check {
 
     /** @var \stdClass $task Record of task that is failing **/
     private $task;
-
 
     /**
      * Constructor
@@ -123,7 +123,7 @@ class failingtaskcheck extends check {
      * @return array of failing tasks
      */
     public static function get_failing_tasks(): array {
-        global $DB,
+        global $DB;
         $tasks = [];
 
         // Instead of using task API here, we read directly from the database.

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -91,47 +91,7 @@ class failingtaskcheck extends check {
             $status = result::ERROR;
         }
 
-        // Cap the status to the maximum allowed by configuration.
-        $status = $this->get_highest_allowed_warning_level($status);
-
         return new result($status, $this->task->message, '');
-    }
-
-
-    /**
-     * Look at the task warning configuration and apply the global default, or if a specific task
-     * default is supplied in the configuration, use that, and then cap the status to either the passed
-     * in real status, or the maximum permitted in config if the real status exceeds it.
-     * @param string $status
-     * @return string Allowed status
-     */
-    public function get_highest_allowed_warning_level($status) {
-        // No configuration exists, short circuit.
-        if (!isset($this->config)) {
-            return $status;
-        }
-        // Before any configuration tests, the default max allowed is the same as the status reported.
-        $max = $status;
-        // If there's a global task default, apply that first.
-        if (isset($this->config['*']) && isset($this->config['*']['maxfaildelaylevel'])) {
-            $max = $this->config['*']['maxfaildelaylevel'];
-        }
-        // Now look for specific config for the task classname, this takes precedence.
-        if (isset($this->task) &&
-            isset($this->config[$this->task->classname])
-            && isset($this->config[$this->task->classname]['maxfaildelaylevel'])) {
-            $max = $this->config[$this->task->classname]['maxfaildelaylevel'];
-        }
-        // Get a map of result string to integers representing their "order level".
-        $map = checker::RESULT_MAPPING;
-        // Get the order value of each status.
-        $maxint = $map[$max];
-        $realint = $map[$status];
-        // Determine the lowest ordered status of the two.
-        $finalint = min($maxint, $realint);
-        // Flip the array to be integer => string constant and return the allowed final status.
-        return array_flip($map)[$finalint];
-
     }
 
     /**

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -178,8 +178,6 @@ class failingtaskcheck extends check {
         return trim(str_replace('\\', '_', $this->task->classname), '_');
     }
 
-
-
     /**
      * Gets an array of all failing tasks, stored as \stdClass.
      *

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -15,7 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_heartbeat\check;
-use tool_heartbeat\checker;
 use core\check\check;
 use core\check\result;
 
@@ -40,15 +39,12 @@ class failingtaskcheck extends check {
     /** @var \stdClass $task Record of task that is failing **/
     private $task;
 
-    /** @var \stdClass $config Configuration of task alerting defaults */
-    private $config;
 
     /**
      * Constructor
      */
-    public function __construct($task = null, $config = null) {
+    public function __construct($task = null) {
         $this->task = $task;
-        $this->config = $config;
 
     }
 
@@ -127,7 +123,7 @@ class failingtaskcheck extends check {
      * @return array of failing tasks
      */
     public static function get_failing_tasks(): array {
-        global $DB, $CFG;
+        global $DB,
         $tasks = [];
 
         // Instead of using task API here, we read directly from the database.
@@ -136,7 +132,7 @@ class failingtaskcheck extends check {
 
         foreach ($scheduledtasks as $task) {
             $task->message = "SCHEDULED TASK: {$task->classname} Delay: {$task->faildelay}\n";
-            $tasks[] = new \tool_heartbeat\check\failingtaskcheck($task, $CFG->tool_heartbeat_tasks);
+            $tasks[] = new \tool_heartbeat\check\failingtaskcheck($task);
         }
 
         // Instead of using task API here, we read directly from the database.
@@ -151,7 +147,7 @@ class failingtaskcheck extends check {
             // Only add duplicate message if there are more than 1.
             $duplicatemsg = $record->count > 1 ? " ({$record->count} duplicates!!!)" : '';
             $record->message = "ADHOC TASK: {$record->classname} Delay: {$record->faildelay} {$duplicatemsg}\n";
-            $tasks[] = new \tool_heartbeat\check\failingtaskcheck($record, $CFG->tool_heartbeat_tasks);
+            $tasks[] = new \tool_heartbeat\check\failingtaskcheck($record);
         }
         return $tasks;
     }

--- a/classes/checker.php
+++ b/classes/checker.php
@@ -50,6 +50,17 @@ class checker {
         result::UNKNOWN => resultmessage::LEVEL_UNKNOWN,
     ];
 
+    /** @var array Map check result to nagios level **/
+    public const RESULT_ORDER = [
+        result::NA          => 0,
+        result::INFO        => 1,
+        result::OK          => 2,
+        result::WARNING     => 3,
+        result::UNKNOWN     => 4,
+        result::ERROR       => 5,
+        result::CRITICAL    => 6,
+    ];
+
     /**
      * Returns an array of check API messages.
      * If exceptions are thrown, they are caught and returned as result messages as well.
@@ -347,7 +358,7 @@ class checker {
             return $result;
         }
         // Get a map of result string to integers representing their "order level".
-        $map = checker::RESULT_MAPPING;
+        $map = checker::RESULT_ORDER;
         // Get the order value of each status.
         $maxint = $map[$max];
         $realint = $map[$status];


### PR DESCRIPTION
Closes #200

This allows the user to configure a maximum permitted check level for checks.

The configuration is stored in the site config.php under the config setting $CFG->tool_heartbeat_check_defaults

This should be an array with a form like the following

```php
$CFG->tool_heartbeat_check_defaults = [
    '.+_task_.+' => [
        'maxwarninglevel' => 'info',
    ],
    'core_task_tag_cron_task' => [
        'maxwarninglevel' => 'critical',
    ],
    'tool_task_.*' => [
        'maxwarninglevel' => 'critical',
    ],
];
```
The top level array keys are tested against the check reference string one by one, via the use of preg_match, if it does match, the resulting check's status is compared to the `maxwarninglevel` and if it exceeds it, it is replaced by the max warning level setting.

if multiple settings match, the last in the configuration array is the one that will take precedence, to allow for broader defaults and then more detailed specific overrides.

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)
