### PR TITLE
[#174] Add error log check back in

### DIFF
--- a/classes/lib.php
+++ b/classes/lib.php
@@ -100,5 +100,33 @@ class lib {
         error_log("Heartbeat cache was checked: " . json_encode($details));
         // @codingStandardsIgnoreEnd
     }
+
+    /**
+     * Handles error logging pinging. This happens on a regular schedule e.g. every 30 mins.
+     * This is used in conjunction with external monitoring services to monitor if the error log is fresh
+     * (or alternatively if it is stale, because the logs are not coming through anymore).
+     */
+    public static function process_error_log_ping() {
+        $lastpinged = get_config('tool_heartbeat', 'errorloglastpinged') ?: 0;
+        $errorperiod = get_config('tool_heartbeat', 'errorlog');
+
+        // If zero/null - disabled - don't do anything.
+        if (empty($errorperiod)) {
+            return;
+        }
+
+        if (($lastpinged + $errorperiod) < time()) {
+            // Update the last pinged time.
+            set_config('errorloglastpinged', time(), 'tool_heartbeat');
+
+            // Log to error_log.
+            $now = userdate(time());
+            $period = format_time($errorperiod);
+
+            // @codingStandardsIgnoreStart
+            error_log("Heartbeat error log test $now, next test expected in $period");
+            // @codingStandardsIgnoreEnd
+        }
+    }
 }
 

--- a/croncheck.php
+++ b/croncheck.php
@@ -57,6 +57,8 @@ if ($isweb) {
 }
 
 use tool_heartbeat\checker;
+use tool_heartbeat\lib;
+
 global $PAGE;
 
 if (isset($CFG->mnet_dispatcher_mode) and $CFG->mnet_dispatcher_mode !== 'off') {
@@ -67,6 +69,8 @@ if (isset($CFG->mnet_dispatcher_mode) and $CFG->mnet_dispatcher_mode !== 'off') 
 // Start output buffering. This stops for e.g. debugging messages from breaking the output.
 // The checker class collects this, and if anything it output it shows a warning.
 ob_start();
+
+lib::process_error_log_ping();
 
 $messages = checker::get_check_messages();
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024080200;
-$plugin->release   = 2024080200; // Match release exactly to version.
+$plugin->version   = 2024111400;
+$plugin->release   = 2024111400; // Match release exactly to version.
 $plugin->requires  = 2020061500; // Support for 3.9 and above, due to the Check API.
 $plugin->supported = [39, 404];
 $plugin->component = 'tool_heartbeat';


### PR DESCRIPTION
Closes #174 

## Changes
- Adds back in the error log pinging, which was removed during a cleanup.
- Added just into the croncheck page instead of check api. If we had the ability to read back the error log to do a complete e2e test, it would be a check class, but since we cannot there's no point since the check can't actually check anything.

## Testing
- Covered by unit tests
- Also tested manually

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)
