### PR TITLE
203 fix error log tests

### DIFF
--- a/aborttest.php
+++ b/aborttest.php
@@ -41,7 +41,7 @@ $PAGE->set_url($url);
 $PAGE->set_context($syscontext);
 $PAGE->set_pagelayout('standard');
 $PAGE->set_cacheable(false);
-$url->params(array('stage' => 2));
+$url->params(['stage' => 2]);
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('testabort', 'tool_heartbeat'));
 

--- a/adminloginchecker.php
+++ b/adminloginchecker.php
@@ -37,11 +37,11 @@ defined('MOODLE_INTERNAL');
 define('NO_UPGRADE_CHECK', true);
 // @codingStandardsIgnoreEnd
 
-$options = array(
+$options = [
     'help' => false,
     'critthresh' => 60 * 60 * 24 * 3,
     'warnthresh' => 60 * 60 * 24 * 7,
-);
+];
 
 if (isset($argv)) {
     // If run from the CLI.
@@ -51,9 +51,9 @@ if (isset($argv)) {
     require_once($CFG->libdir . '/clilib.php');
 
     list($options, $unrecognized) = cli_get_params($options,
-    array(
+    [
         'h' => 'help',
-        )
+        ]
     );
 
     if ($unrecognized) {

--- a/buffercheck.php
+++ b/buffercheck.php
@@ -73,7 +73,7 @@ if ($response !== false) {
 
 $files = [
     $CFG->dirroot . '/backup/backup.php',
-    $CFG->dirroot . '/backup/restore.php'
+    $CFG->dirroot . '/backup/restore.php',
 ];
 
 foreach ($files as $file) {

--- a/classes/check/authcheck.php
+++ b/classes/check/authcheck.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Auth method health check.
  *
@@ -56,7 +57,7 @@ class authcheck extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         global $DB;
 
         // Value must be raw DB value. We will see it here before in settings cache.

--- a/classes/check/cachecheck.php
+++ b/classes/check/cachecheck.php
@@ -36,7 +36,7 @@ class cachecheck extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         $results = $this->check('web');
         $results += $this->check('cron');
 

--- a/classes/check/dirsizes.php
+++ b/classes/check/dirsizes.php
@@ -41,7 +41,7 @@ class dirsizes extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         global $CFG;
 
         $sizedataroot = get_directory_size($CFG->dataroot);

--- a/classes/check/dnscheck.php
+++ b/classes/check/dnscheck.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * DNS security check.
  *
@@ -40,7 +41,7 @@ class dnscheck extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         global $DB, $CFG;
 
         $url = new \moodle_url($CFG->wwwroot);

--- a/classes/check/failingtaskcheck.php
+++ b/classes/check/failingtaskcheck.php
@@ -62,7 +62,7 @@ class failingtaskcheck extends check {
      * Return result
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
         global $DB;
 
         // Return OK if no task errors.

--- a/classes/check/rangerequestcheck.php
+++ b/classes/check/rangerequestcheck.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Range request performance check.
  *
@@ -47,7 +48,7 @@ class rangerequestcheck extends check {
      *
      * @return result
      */
-    public function get_result() : result {
+    public function get_result(): result {
 
         $url = new \moodle_url('/pluginfile.php/1/tool_heartbeat/test');
 

--- a/classes/check/tasklatencycheck.php
+++ b/classes/check/tasklatencycheck.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Individual cron task latency monitoring check check.
  *

--- a/classes/checker.php
+++ b/classes/checker.php
@@ -358,7 +358,7 @@ class checker {
             return $result;
         }
         // Get a map of result string to integers representing their "order level".
-        $map = checker::RESULT_ORDER;
+        $map = self::RESULT_ORDER;
         // Get the order value of each status.
         $maxint = $map[$max];
         $realint = $map[$status];
@@ -366,7 +366,7 @@ class checker {
         $finalint = min($maxint, $realint);
         // Flip the array to be integer => string constant and return the allowed
         // final status.
-        $status =  array_flip($map)[$finalint];
+        $status = array_flip($map)[$finalint];
         return new result($status, $result->get_summary(), $result->get_details());
     }
     /**

--- a/classes/form/override_form.php
+++ b/classes/form/override_form.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Override form
  *

--- a/classes/object/override.php
+++ b/classes/object/override.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  *
  * Heartbeat override
@@ -44,7 +45,6 @@ class override extends Persistent {
      * @param int $id If set, this is the id of an existing record, used to load the data.
      * @param \stdClass $record If set will be passed to {@link self::from_record()}.
      */
-
     public function __construct(int $id = 0, \stdClass $record = null) {
         $this->set_default_status();
         $this->set_default_expiry();

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Privacy Subsystem implementation for tool_heartbeat.
  *

--- a/classes/task/cachecheck.php
+++ b/classes/task/cachecheck.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 namespace tool_heartbeat\task;
 
 /**

--- a/cli/testupload.php
+++ b/cli/testupload.php
@@ -32,22 +32,22 @@ require(__DIR__ . '/../../../../config.php');
 require_once($CFG->libdir.'/clilib.php');
 
 list($options, $unrecognized) = cli_get_params(
-    array(
+    [
         'help'    => false,
         'size'    => 1024 * 10,
         'chunks'  => 100,
         'delay'   => 0,
         'wwwroot' => $CFG->wwwroot,
         'verbose' => 0,
-    ),
-    array(
+    ],
+    [
         'h'   => 'help',
         's'   => 'size',
         'c'   => 'chunks',
         'd'   => 'delay',
         'w'   => 'wwwroot',
         'v'   => 'verbose',
-    )
+    ]
 );
 
 if ($unrecognized) {

--- a/db/install.php
+++ b/db/install.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Cache split check.
  *

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -13,12 +13,14 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Tool heartbeat
  *
  * @author     Brendan Heywood <brendan@catalyst-au.net>
  * @copyright  Catalyst IT 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @package tool_heartbeat
  */
 
 defined('MOODLE_INTERNAL') || die();

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * DB upgrade script.
  *

--- a/errors.php
+++ b/errors.php
@@ -34,6 +34,7 @@ $PAGE->set_context($syscontext);
 echo $OUTPUT->header();
 echo $OUTPUT->heading('Tests for all errors in the whole stack');
 
+// @codingStandardsIgnoreStart
 ?>
 <h3>Moodle high level errors</h3>
 <p>These should all use the moodle theme</p>
@@ -74,6 +75,7 @@ echo $OUTPUT->heading('Tests for all errors in the whole stack');
 <li>A 502 Bad Gateway, proxy cannot connect at all (how to test?)</li>
 
 <?php
+// @codingStandardsIgnoreEnd
 
 echo $OUTPUT->footer();
 

--- a/errors/phpwarnings.php
+++ b/errors/phpwarnings.php
@@ -36,6 +36,8 @@ echo "This is an ok page which emits notices and warnings, and error logs";
 trigger_error("This is a notice", E_USER_NOTICE);
 trigger_error("This is a warning", E_USER_WARNING);
 
+// @codingStandardsIgnoreStart
 error_log("This is an error_log");
+// @codingStandardsIgnoreEnd
 file_put_contents("php://stderr", "This writing to php://stderr");
 

--- a/index.php
+++ b/index.php
@@ -125,7 +125,7 @@ if (!(isset($argv))) {
 }
 
 if ($fullcheck || $checksession) {
-    $c = new curl(array('cache' => false, 'cookie' => true));
+    $c = new curl(['cache' => false, 'cookie' => true]);
     $response = $c->get(new moodle_url('/admin/tool/heartbeat/sessionone.php'));
     if ($sessioncheck = json_decode($response)) {
         if ($sessioncheck->success == 'pass') {

--- a/lib.php
+++ b/lib.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Callback point.
  *
@@ -85,7 +86,7 @@ function tool_heartbeat_security_checks() {
  * @param array $options More options
  * @return bool Returns false if we don't find a file.
  */
-function tool_heartbeat_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
+function tool_heartbeat_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
     global $CFG;
 
     // README is just safe content we know exist. Used in the range request check.

--- a/loginchecker.php
+++ b/loginchecker.php
@@ -37,12 +37,12 @@ defined('MOODLE_INTERNAL');
 define('NO_UPGRADE_CHECK', true);
 // @codingStandardsIgnoreEnd
 
-$options = array(
+$options = [
     'help' => false,
     'critthresh' => 500,
     'warnthresh' => 10,
     'logtime' => 5,
-);
+];
 
 if (isset($argv)) {
     // If run from the CLI.
@@ -52,9 +52,9 @@ if (isset($argv)) {
     require_once($CFG->libdir . '/clilib.php');
 
     list($options, $unrecognized) = cli_get_params($options,
-    array(
+    [
         'h' => 'help',
-        )
+        ]
     );
 
     if ($unrecognized) {
@@ -106,7 +106,7 @@ $sqlstring = "SELECT count(*) AS logincount
                WHERE target = 'user_login'
                  AND timecreated > :checktime";
 
-$tablequery = $DB->get_record_sql($sqlstring, array('checktime' => $checktime));
+$tablequery = $DB->get_record_sql($sqlstring, ['checktime' => $checktime]);
 
 $count = $tablequery->logincount;
 

--- a/sessionone.php
+++ b/sessionone.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 /**
  * Set a random integer in session and redirect to check if persists.
  *
@@ -35,10 +34,10 @@ $hostname = gethostname();
 
 $SESSION->testnumber = $testnumber;
 
-$params = array(
+$params = [
     'testnumber' => $testnumber,
     'reqtime' => $testtimemicro,
-    'host' => $hostname);
+    'host' => $hostname];
 $url = new moodle_url('/admin/tool/heartbeat/sessiontwo.php', $params);
 
 redirect($url);

--- a/settings.php
+++ b/settings.php
@@ -41,11 +41,11 @@ if ($hassiteconfig) {
 
     if (!during_initial_install()) {
 
-        $options = array(
+        $options = [
             '' => new lang_string('normal', 'tool_heartbeat'),
             'warn' => new lang_string('testwarning', 'tool_heartbeat'),
             'error' => new lang_string('testerror', 'tool_heartbeat'),
-        );
+        ];
         $settings->add(new admin_setting_configselect('tool_heartbeat/testing',
                         new lang_string('testing',        'tool_heartbeat'),
                         new lang_string('testingdesc',    'tool_heartbeat'),
@@ -94,7 +94,7 @@ if ($hassiteconfig) {
         $opts = [
             'critical' => 'CRITICAL',
             'criticalbusiness' => get_string('error_critical_business', 'tool_heartbeat'),
-            'warning' => 'WARNING'
+            'warning' => 'WARNING',
         ];
         $time = new \DateTime('now', core_date::get_server_timezone_object());
         $settings->add(new admin_setting_configselect('tool_heartbeat/errorcritical',

--- a/tests/check/tasklatencycheck_test.php
+++ b/tests/check/tasklatencycheck_test.php
@@ -71,7 +71,7 @@ class tasklatencycheck_test extends \advanced_testcase {
             // Now set a lock on the task. This should prevent critical.
             $CFG->lock_factory = \tool_lockstats\proxy_lock_factory::class;
             $DB->insert_record('tool_lockstats_locks', [
-                'resourcekey' => '\\logstore_standard\\task\\cleanup_task'
+                'resourcekey' => '\\logstore_standard\\task\\cleanup_task',
             ]);
             $result = $check->get_result();
             $this->assertEquals(result::OK, $result->get_status());
@@ -120,7 +120,7 @@ class tasklatencycheck_test extends \advanced_testcase {
             // Now set a lock on the task. This should prevent critical.
             $CFG->lock_factory = \tool_lockstats\proxy_lock_factory::class;
             $DB->insert_record('tool_lockstats_locks', [
-                'resourcekey' => '\\logstore_standard\\task\\cleanup_task'
+                'resourcekey' => '\\logstore_standard\\task\\cleanup_task',
             ]);
             $result = $check->get_result();
             $this->assertEquals(result::OK, $result->get_status());

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -134,8 +134,8 @@ class checker_test extends \advanced_testcase {
             ],
             'pipe char in output is cleaned' => [
                 'messages' => [$criticalwithpipemsg],
-                'expectedsummary' => str_replace('|', '｜', $criticalwithpipemsg->title)
-            ]
+                'expectedsummary' => str_replace('|', '｜', $criticalwithpipemsg->title),
+            ],
         ];
     }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024111400;
-$plugin->release   = 2024111400; // Match release exactly to version.
+$plugin->version   = 2024111800;
+$plugin->release   = 2024111800; // Match release exactly to version.
 $plugin->requires  = 2020061500; // Support for 3.9 and above, due to the Check API.
 $plugin->supported = [39, 404];
 $plugin->component = 'tool_heartbeat';


### PR DESCRIPTION
Closes #203 

**Changes**
- Made the error log ping not output during unit tests - we don't test for it outputting and it has the potential to pollute the test logs.
- Made the pinging test deterministic by allowing you to pass in the time value, instead of relying on the test time.
- Also fixed Ci errors - I think the CI must have updated recently causing new failures 

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)
