### PR TITLE
Fix for #206 - fix ci badge link master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/catalyst/moodle-tool_heartbeat/ci.yml?branch=master&label=ci)
+[![ci](https://github.com/catalyst/moodle-tool_heartbeat/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/catalyst/moodle-tool_heartbeat/actions/workflows/ci.yml?branch=master)
 
 # A heartbeat test page for Moodle
 


### PR DESCRIPTION
Fix for #206 - fix ci badge link - master branch
