### PR TITLE
Update range request check mimetype

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -91,6 +91,6 @@ function tool_heartbeat_pluginfile($course, $cm, $context, $filearea, $args, $fo
 
     // README is just safe content we know exist. Used in the range request check.
     $file = "$CFG->dirroot/admin/tool/heartbeat/README.md";
-    readfile_accel($file, 'text/plain', true);
+    readfile_accel($file, 'text/markdown', true);
     die;
 }


### PR DESCRIPTION
After investigating reports of the range request check failing, I found that readfile_accel doesn't use range requests for text/plain. In my testing updating the mimetype was enough to resolve this.

### Pull request checks
- [Y] I have checked the version numbers are correct as per the [README](./README.md#branches)
