### PR TITLE
Moodle 39 stable 500 runtests

### DIFF
--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -48,27 +48,27 @@ class checker_test extends \advanced_testcase {
         return [
             'no messages' => [
                 'levels' => [],
-                'nagioslevel' => resultmessage::LEVEL_OK,
+                'expectedlevel' => resultmessage::LEVEL_OK,
             ],
             'one OK message' => [
                 'levels' => [resultmessage::LEVEL_OK],
-                'nagioslevel' => resultmessage::LEVEL_OK,
+                'expectedlevel' => resultmessage::LEVEL_OK,
             ],
             'one UNKNOWN message' => [
                 'levels' => [resultmessage::LEVEL_UNKNOWN],
-                'nagioslevel' => resultmessage::LEVEL_UNKNOWN,
+                'expectedlevel' => resultmessage::LEVEL_UNKNOWN,
             ],
             'one UNKNOWN and one OK' => [
                 'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_OK],
-                'nagioslevel' => resultmessage::LEVEL_UNKNOWN,
+                'expectedlevel' => resultmessage::LEVEL_UNKNOWN,
             ],
             'one UNKNOWN and one WARNING' => [
                 'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_WARN],
-                'nagioslevel' => resultmessage::LEVEL_WARN,
+                'expectedlevel' => resultmessage::LEVEL_WARN,
             ],
             'one UNKNOWN and on CRITICAL' => [
                 'levels' => [resultmessage::LEVEL_UNKNOWN, resultmessage::LEVEL_CRITICAL],
-                'nagioslevel' => resultmessage::LEVEL_CRITICAL,
+                'expectedlevel' => resultmessage::LEVEL_CRITICAL,
             ],
         ];
     }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -52,7 +52,7 @@ class lib_test extends \advanced_testcase {
      * Provides values to test error log ping.
      * @return array
      */
-    public function process_error_log_ping_provider(): array {
+    public static function process_error_log_ping_provider(): array {
         return [
             'no period set - disabled' => [
                 'errorloglastpinged' => null,


### PR DESCRIPTION
For runtests in Moodle 5.0
Resolves "Data Provider method … is not static" error.
Resolves "unknown named parameter" error.