### PR TITLE
Add require for non-autoloaded T20 testcase class

### DIFF
--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -16,6 +16,11 @@
 
 namespace tool_heartbeat;
 
+defined('MOODLE_INTERNAL') || die();
+
+// Required for externallib_advanced_testcase class; cannot use $CFG->dirroot here in phpunit.
+require_once __DIR__ . "/../../../../webservice/tests/helpers.php";
+
 /**
  * Test class for tool_heartbeat\lib
  *


### PR DESCRIPTION
This fixes a unit test issue when running heartbeat tests individually (likely loaded elsewhere, hence undiscovered until now)

```
An error occurred inside PHPUnit.

Message:  Class "externallib_advanced_testcase" not found
```
This class is in a weird spot so not autoloaded - just needed to load it in.

### Pull request checks
- [x] I have checked the version numbers are correct as per the [README](./README.md#branches)
